### PR TITLE
Specify libssl version

### DIFF
--- a/ruby_packager.sh
+++ b/ruby_packager.sh
@@ -29,7 +29,7 @@ fpm \
   -m "Stefano Zanella <zanella.stefano@gmail.com>" \
   -d libgmp10 \
   -d libyaml-0-2 \
-  -d libssl \
+  -d libssl1.0.0 \
   --replaces ruby \
   --description "Ruby interpreter and associated runtime. Bundler gem included." \
   ${BUILD_DIR}/=/


### PR DESCRIPTION
Without specific the version the dependencies of the package were broken and I wasn't able to install the ruby version from the deb package.

Thank you for this tool, it's awesome!
